### PR TITLE
Bugfix: Wrong Package name for Ubuntu 24

### DIFF
--- a/help/desktop-client.md
+++ b/help/desktop-client.md
@@ -64,7 +64,7 @@ To safely install a package from Ubuntu Jammy repositories without breaking your
 
     ```bash
     sudo apt update
-    sudo apt install -t jammy libwebkit2gtk-4.0
+    sudo apt install -t jammy libwebkit2gtk-4.0-37
     ```
 4. **Optionaly: Remove Jammy Repo After Use:**\
    Delete or comment out the Jammy entry in `/etc/apt/sources.list`.


### PR DESCRIPTION
Hello !

While trying to redirect our user that upgraded to Ubuntu 24 to your documentation, many of them got back to us saying that they couldn't install `libwebkit2gtk-4.0` to get defguard client working.

After trying on a VM, it turn out that the pkg is in fact called `libwebkit2gtk-4.0-37` in the jammy repository.
